### PR TITLE
Add core docs dropdown

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -65,7 +65,7 @@
         }
 
         .list-group-scrollable {
-            height: 452px;
+            height: 453px;
             overflow-y: scroll;
         }
 

--- a/html/index.html
+++ b/html/index.html
@@ -24,14 +24,10 @@
 
     <title>Nautobot Documentation</title>
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" rel="stylesheet"
-        integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="icon" href="assets/img/favicon.ico">
-
-    <!-- <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
-        crossorigin="anonymous"></script>  -->
 
     <style>
         .bi {
@@ -129,8 +125,28 @@
                                 learn how to install, configure, manage, and extend Nautobot.</p>
                         </div>
                         <ul class="list-group list-group-flush border-bottom-0">
-                            <li class="list-group-item"><a href="https://docs.nautobot.com/projects/core/en/stable/"
-                                    class="w-100 btn btn-lg btn-primary">To the Core Docs!</a></li>
+                            <li class="list-group-item">
+                                <div class="w-100 btn-group">
+                                    <a href="https://docs.nautobot.com/projects/core/en/stable/"
+                                        class="btn btn-lg btn-primary">Open Core Docs (Stable)</a>
+                                    <button type="button"
+                                        class="w-20 btn btn-lg btn-primary dropdown-toggle dropdown-toggle-split"
+                                        data-bs-toggle="dropdown" aria-expanded="false">
+                                        <span class="visually-hidden">Toggle Dropdown</span>
+                                    </button>
+                                    <ul class="dropdown-menu">
+                                        <li><a class="dropdown-item"
+                                                href="https://docs.nautobot.com/projects/core/en/ltm-1.6/">LTM 1.6
+                                                Docs</a></li>
+                                        <li><a class="dropdown-item"
+                                                href="https://docs.nautobot.com/projects/core/en/latest/">Latest
+                                                Development Docs</a></li>
+                                        <li><a class="dropdown-item"
+                                                href="https://docs.nautobot.com/projects/core/en/next/">Next Docs</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </li>
                         </ul>
                         <ul class="list-group list-group-flush list-group-scrollable">
                             <li class="list-group-item"><a
@@ -154,7 +170,8 @@
                             <li class="list-group-item"><a href="https://nautobot-ansible.readthedocs.io/en/latest/#"
                                     class="link-dark">Nautobot Ansible Collection</a><span
                                     class="badge text-bg-dark rounded-pill ms-1">Ansible</span></li>
-                            <li class="list-group-item"><a href="https://docs.nautobot.com/projects/pynautobot/en/latest/index.html"
+                            <li class="list-group-item"><a
+                                    href="https://docs.nautobot.com/projects/pynautobot/en/latest/index.html"
                                     class="link-dark">Python Library: pynautobot</a><span
                                     class="badge text-bg-dark rounded-pill ms-1">SDK</span></li>
                             <li class="list-group-item"><a
@@ -336,6 +353,9 @@
             </div>
         </div>
     </footer>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+        crossorigin="anonymous"></script>
     <!-- GA -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-0D1VN0PBG2"></script>
     <script>

--- a/html/index.html
+++ b/html/index.html
@@ -65,7 +65,7 @@
         }
 
         .list-group-scrollable {
-            height: 390px;
+            height: 452px;
             overflow-y: scroll;
         }
 


### PR DESCRIPTION
Add core docs dropdown for easier navigation to the different branch docs.
Updated bootstrap to latest 5.x version.
Slightly taller list group removes scrollbar on the left-hand card.

![image](https://github.com/user-attachments/assets/4cfa2428-d231-4f47-bb7d-1a1bc43389b9)
